### PR TITLE
⚡ perf: remove unnecessary SKShapeNode allocation

### DIFF
--- a/GBPageControl/PageControl.swift
+++ b/GBPageControl/PageControl.swift
@@ -72,9 +72,8 @@ public class PageControl: NSObject {
     private func addIndicator() {
         pageIndicatorNode = SKNode()
         pageIndicators = [SKShapeNode]()
-        let unusedCircleNode = SKShapeNode(circleOfRadius: radius)
-        let pageIndicatorWidth = unusedCircleNode.frame.width * CGFloat(numberOfPages) + CGFloat(numberOfPages - 1) * xMargin
-        let pageIndicatorHeight = unusedCircleNode.frame.height
+        let pageIndicatorWidth = (radius * 2.0) * CGFloat(numberOfPages) + CGFloat(numberOfPages - 1) * xMargin
+        let pageIndicatorHeight = radius * 2.0
         let selectedPage = getSelectedPage()
         for i in 0...numberOfPages - 1 {
             let pageCircle = SKShapeNode(circleOfRadius: radius)


### PR DESCRIPTION
💡 **What:** Replaced the explicit allocation of `unusedCircleNode` with mathematically derived dimensions (`radius * 2.0`) to calculate `pageIndicatorWidth` and `pageIndicatorHeight` in `addIndicator()`.

🎯 **Why:** Creating a throwaway `SKShapeNode` simply to determine its resulting frame dimensions adds unnecessary overhead (CPU, memory allocation) during indicator setup.

📊 **Measured Improvement:** The `swift` and `xcodebuild` environments are unavailable to measure baseline and post-change performance. However, removing an unneeded object allocation inherently provides a net reduction in UI overhead by avoiding the initialization cost and garbage collection / reference counting overhead associated with `SKShapeNode`.

---
*PR created automatically by Jules for task [2944114691005413024](https://jules.google.com/task/2944114691005413024) started by @jhurt*