### PR TITLE
🧹 Refactor indicator color assignment logic in PageControl

### DIFF
--- a/GBPageControl/PageControl.swift
+++ b/GBPageControl/PageControl.swift
@@ -78,12 +78,7 @@ public class PageControl: NSObject {
         let selectedPage = getSelectedPage()
         for i in 0...numberOfPages - 1 {
             let pageCircle = SKShapeNode(circleOfRadius: radius)
-            if i == selectedPage {
-                pageCircle.fillColor = selectedColor
-            }
-            else {
-                pageCircle.fillColor = notSelectedColor
-            }
+            pageCircle.fillColor = i == selectedPage ? selectedColor : notSelectedColor
             pageCircle.strokeColor = pageCircle.fillColor
             pageCircle.position = CGPoint(x: (pageCircle.frame.size.width * CGFloat(i)) + (xMargin * CGFloat(i)) + (pageCircle.frame.size.width/2.0), y:0.0)
             pageIndicatorNode.addChild(pageCircle)
@@ -131,12 +126,7 @@ public class PageControl: NSObject {
         let selectedPage = getSelectedPage()
         for i in 0...pageIndicators!.count - 1 {
             let circle = pageIndicators![i]
-            if i == selectedPage {
-                circle.fillColor = selectedColor
-            }
-            else {
-                circle.fillColor = notSelectedColor
-            }
+            circle.fillColor = i == selectedPage ? selectedColor : notSelectedColor
             circle.strokeColor = circle.fillColor
         }
     }


### PR DESCRIPTION
🎯 **What:** Replaced duplicated `if/else` logic with concise ternary operators for setting indicator color in `pageStateDidChange` and `addIndicator`.
💡 **Why:** This makes the code DRY and improves maintainability and readability by using standard Swift idioms.
✅ **Verification:** Verified through code review that the refactored code is equivalent and doesn't change existing behavior.
✨ **Result:** A cleaner, more maintainable file with less redundant logic.

---
*PR created automatically by Jules for task [17562353124306916921](https://jules.google.com/task/17562353124306916921) started by @jhurt*