### PR TITLE
🧹 Refactor deprecated UIGestureRecognizerState enum usage

### DIFF
--- a/GBPageControl/PageControl.swift
+++ b/GBPageControl/PageControl.swift
@@ -99,11 +99,11 @@ public class PageControl: NSObject {
     }
     
     @objc public func handlePanGesture(recognizer: UIPanGestureRecognizer) {
-        if recognizer.state == UIGestureRecognizerState.began {
+        if recognizer.state == .began {
             panGestureStartPoint = parentScene?.convertPoint(fromView: recognizer.location(in: recognizer.view))
             panGestureStartContentPosition = contentNode.position
         }
-        else if recognizer.state == UIGestureRecognizerState.changed {
+        else if recognizer.state == .changed {
             if panGestureStartPoint != nil {
                 let touchPoint = parentScene?.convertPoint(fromView: recognizer.location(in: recognizer.view))
                 let velocity = recognizer.velocity(in: recognizer.view!)
@@ -116,7 +116,7 @@ public class PageControl: NSObject {
                 panGestureStartPoint = touchPoint
             }
         }
-        else if recognizer.state == UIGestureRecognizerState.ended {
+        else if recognizer.state == .ended {
             panGestureStartPoint = nil
             panGestureStartContentPosition = nil
             let page = getSelectedPage()


### PR DESCRIPTION
🎯 **What:** Replaced the explicit use of `UIGestureRecognizerState.began`, `.changed`, and `.ended` with the shorthand `.began`, `.changed`, and `.ended` syntax in `GBPageControl/PageControl.swift`.

💡 **Why:** This change follows modern Swift styling guidelines, making the code more readable and concise, and resolves potential deprecation warnings associated with explicit reference to the full enum type names.

✅ **Verification:** Verified by grep that there are no remaining instances of `UIGestureRecognizerState` anywhere in the codebase. Tests could not be run because `swift test` and `xcodebuild test` commands are not available in the environment, but the changes are a simple refactoring to utilize modern shorthand Swift syntax and have no logic changes. Code review verified the change as completely correct and zero-risk.

✨ **Result:** Improved Swift code quality and maintainability, staying up to date with modern best practices, without changing any runtime behavior.

---
*PR created automatically by Jules for task [8016875485186484966](https://jules.google.com/task/8016875485186484966) started by @jhurt*