### PR TITLE
🧹 Remove unnecessary SKShapeNode allocation

### DIFF
--- a/GBPageControl/PageControl.swift
+++ b/GBPageControl/PageControl.swift
@@ -72,9 +72,9 @@ public class PageControl: NSObject {
     private func addIndicator() {
         pageIndicatorNode = SKNode()
         pageIndicators = [SKShapeNode]()
-        let unusedCircleNode = SKShapeNode(circleOfRadius: radius)
-        let pageIndicatorWidth = unusedCircleNode.frame.width * CGFloat(numberOfPages) + CGFloat(numberOfPages - 1) * xMargin
-        let pageIndicatorHeight = unusedCircleNode.frame.height
+        let diameter = radius * 2.0
+        let pageIndicatorWidth = diameter * CGFloat(numberOfPages) + CGFloat(numberOfPages - 1) * xMargin
+        let pageIndicatorHeight = diameter
         let selectedPage = getSelectedPage()
         for i in 0...numberOfPages - 1 {
             let pageCircle = SKShapeNode(circleOfRadius: radius)
@@ -85,7 +85,7 @@ public class PageControl: NSObject {
                 pageCircle.fillColor = notSelectedColor
             }
             pageCircle.strokeColor = pageCircle.fillColor
-            pageCircle.position = CGPoint(x: (pageCircle.frame.size.width * CGFloat(i)) + (xMargin * CGFloat(i)) + (pageCircle.frame.size.width/2.0), y:0.0)
+            pageCircle.position = CGPoint(x: (diameter * CGFloat(i)) + (xMargin * CGFloat(i)) + (diameter/2.0), y:0.0)
             pageIndicatorNode.addChild(pageCircle)
             pageIndicators.append(pageCircle)
         }


### PR DESCRIPTION
🎯 **What:** Removed unnecessary allocation of `SKShapeNode` in `addIndicator()`.
💡 **Why:** The unused node was only allocated to retrieve its frame width and height. By computing the diameter as `radius * 2.0`, we avoid an unnecessary memory allocation and improve layout performance slightly. Also updated layout calculation inside the loop to use `diameter` directly rather than accessing `pageCircle.frame.size.width`.
✅ **Verification:** Verified via manual inspection since the environment lacks `xcodebuild`. Code review approved the changes.
✨ **Result:** A more efficient setup that requires one fewer SKShapeNode instantiation and removes multiple `frame.size.width` accesses per indicator.

---
*PR created automatically by Jules for task [162626133340263093](https://jules.google.com/task/162626133340263093) started by @jhurt*