### PR TITLE
⚡ [Performance] Avoid expensive frame calculations in addIndicator loop

### DIFF
--- a/GBPageControl/PageControl.swift
+++ b/GBPageControl/PageControl.swift
@@ -85,7 +85,7 @@ public class PageControl: NSObject {
                 pageCircle.fillColor = notSelectedColor
             }
             pageCircle.strokeColor = pageCircle.fillColor
-            pageCircle.position = CGPoint(x: (pageCircle.frame.size.width * CGFloat(i)) + (xMargin * CGFloat(i)) + (pageCircle.frame.size.width/2.0), y:0.0)
+            pageCircle.position = CGPoint(x: ((radius * 2.0) * CGFloat(i)) + (xMargin * CGFloat(i)) + radius, y:0.0)
             pageIndicatorNode.addChild(pageCircle)
             pageIndicators.append(pageCircle)
         }


### PR DESCRIPTION
💡 **What:** Replaced dynamic property accesses to `pageCircle.frame.size.width` within the `addIndicator` loop with a pre-calculated mathematical equivalent based on the predefined `radius` property.

🎯 **Why:** Accessing `frame.size.width` on an `SKShapeNode` forces an expensive recalculation of its bounding box. Doing this repeatedly within a loop creates unnecessary overhead and stalls layout rendering. By substituting it with `radius * 2.0`, the visual outcome remains identical while bypassing the performance penalty completely.

📊 **Measured Improvement:** We were unable to explicitly benchmark this change because the development environment lacks the required Swift/Xcode CLI tools needed to compile or execute Swift benchmarks. However, avoiding SpriteKit bounding box calculations during loops is a widely accepted rendering optimization, reducing CPU overhead during indicator initialization.

---
*PR created automatically by Jules for task [2595776754777107726](https://jules.google.com/task/2595776754777107726) started by @jhurt*