### PR TITLE
🔒 Remove unsafe force unwrapping of optionals

### DIFF
--- a/GBPageControl/PageControl.swift
+++ b/GBPageControl/PageControl.swift
@@ -3,16 +3,16 @@ import SpriteKit
 public class PageControl: NSObject {
     weak var parentScene:SKScene?
     
-    var contentNode:SKNode!
+    var contentNode:SKNode = SKNode()
     
-    var panGestureRecognizer:UIPanGestureRecognizer!
-    var panGestureStartPoint:CGPoint!
-    var panGestureStartContentPosition:CGPoint!
+    var panGestureRecognizer:UIPanGestureRecognizer?
+    var panGestureStartPoint:CGPoint?
+    var panGestureStartContentPosition:CGPoint?
     
-    var pageIndicatorNode:SKNode!
-    var pageIndicators:[SKShapeNode]!
+    var pageIndicatorNode:SKNode?
+    var pageIndicators:[SKShapeNode] = []
     
-    var numberOfPages:Int!
+    var numberOfPages:Int = 0
     
     public var xMargin:CGFloat = 8.0
     public var radius:CGFloat = 8.0
@@ -22,12 +22,12 @@ public class PageControl: NSObject {
     
     public init(scene:SKScene) {
         self.parentScene = scene
-        contentNode = SKNode()
+        super.init()
         parentScene?.addChild(contentNode)
     }
     
     public func addChild(_ node:SKNode) {
-        contentNode!.addChild(node)
+        contentNode.addChild(node)
     }
     
     public func enable(numberOfPages:Int) {
@@ -38,28 +38,30 @@ public class PageControl: NSObject {
     }
     
     public func getSelectedPage() -> Int {
-        return -1 * Int(floor((contentNode.position.x + parentScene!.size.width/2.0) / parentScene!.size.width))
+        guard let parentScene = parentScene else { return 0 }
+        return -1 * Int(floor((contentNode.position.x + parentScene.size.width/2.0) / parentScene.size.width))
     }
     
     public func willMove(from view: SKView) {
-        if panGestureRecognizer != nil {
+        if let panGestureRecognizer = panGestureRecognizer {
             view.removeGestureRecognizer(panGestureRecognizer)
         }
     }
     
     public func handleTouch(touch: UITouch) -> Bool {
-        let location = touch.location(in: pageIndicatorNode!)
+        guard let pageIndicatorNode = pageIndicatorNode, let parentScene = parentScene else { return false }
+        let location = touch.location(in: pageIndicatorNode)
         let touchMargin:CGFloat = xMargin / 2.0
-        for i in 0...pageIndicators!.count - 1 {
-            let indicator = pageIndicators![i]
+        for i in 0..<pageIndicators.count {
+            let indicator = pageIndicators[i]
             let indicatorTouchRect = CGRect(x:indicator.frame.origin.x - touchMargin,
                                             y:indicator.frame.origin.y - touchMargin,
                                             width:indicator.frame.width + touchMargin * 2.0,
                                             height:indicator.frame.height + touchMargin * 2.0)
             if indicatorTouchRect.contains(location) {
-                let point = CGPoint(x:-1.0 * CGFloat(i) * parentScene!.size.width,
-                                    y:contentNode!.position.y)
-                contentNode!.run(SKAction.move(to: point, duration:0.2),
+                let point = CGPoint(x:-1.0 * CGFloat(i) * parentScene.size.width,
+                                    y:contentNode.position.y)
+                contentNode.run(SKAction.move(to: point, duration:0.2),
                                  completion: { [weak self] in
                                     self?.pageStateDidChange()
                                 })
@@ -70,13 +72,15 @@ public class PageControl: NSObject {
     }
     
     private func addIndicator() {
-        pageIndicatorNode = SKNode()
+        guard let parentScene = parentScene else { return }
+        let newPageIndicatorNode = SKNode()
+        pageIndicatorNode = newPageIndicatorNode
         pageIndicators = [SKShapeNode]()
         let unusedCircleNode = SKShapeNode(circleOfRadius: radius)
         let pageIndicatorWidth = unusedCircleNode.frame.width * CGFloat(numberOfPages) + CGFloat(numberOfPages - 1) * xMargin
         let pageIndicatorHeight = unusedCircleNode.frame.height
         let selectedPage = getSelectedPage()
-        for i in 0...numberOfPages - 1 {
+        for i in 0..<numberOfPages {
             let pageCircle = SKShapeNode(circleOfRadius: radius)
             if i == selectedPage {
                 pageCircle.fillColor = selectedColor
@@ -86,51 +90,56 @@ public class PageControl: NSObject {
             }
             pageCircle.strokeColor = pageCircle.fillColor
             pageCircle.position = CGPoint(x: (pageCircle.frame.size.width * CGFloat(i)) + (xMargin * CGFloat(i)) + (pageCircle.frame.size.width/2.0), y:0.0)
-            pageIndicatorNode.addChild(pageCircle)
+            newPageIndicatorNode.addChild(pageCircle)
             pageIndicators.append(pageCircle)
         }
-        pageIndicatorNode.position = CGPoint(x:parentScene!.frame.midX - pageIndicatorWidth/2.0, y:yPosition + pageIndicatorHeight/2.0)
-        parentScene?.addChild(pageIndicatorNode)
+        newPageIndicatorNode.position = CGPoint(x:parentScene.frame.midX - pageIndicatorWidth/2.0, y:yPosition + pageIndicatorHeight/2.0)
+        parentScene.addChild(newPageIndicatorNode)
     }
     
     private func addPanGestureRecognizer() {
-        panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(PageControl.handlePanGesture(recognizer:)))
-        parentScene?.view?.addGestureRecognizer(panGestureRecognizer)
+        let recognizer = UIPanGestureRecognizer(target: self, action: #selector(PageControl.handlePanGesture(recognizer:)))
+        panGestureRecognizer = recognizer
+        if let parentScene = parentScene, let view = parentScene.view {
+            view.addGestureRecognizer(recognizer)
+        }
     }
     
     @objc public func handlePanGesture(recognizer: UIPanGestureRecognizer) {
+        guard let parentScene = parentScene, let view = recognizer.view else { return }
+
         if recognizer.state == UIGestureRecognizerState.began {
-            panGestureStartPoint = parentScene?.convertPoint(fromView: recognizer.location(in: recognizer.view))
+            panGestureStartPoint = parentScene.convertPoint(fromView: recognizer.location(in: view))
             panGestureStartContentPosition = contentNode.position
         }
         else if recognizer.state == UIGestureRecognizerState.changed {
-            if panGestureStartPoint != nil {
-                let touchPoint = parentScene?.convertPoint(fromView: recognizer.location(in: recognizer.view))
-                let velocity = recognizer.velocity(in: recognizer.view!)
+            if let panGestureStartPoint = panGestureStartPoint, let panGestureStartContentPosition = panGestureStartContentPosition {
+                let touchPoint = parentScene.convertPoint(fromView: recognizer.location(in: view))
+                let velocity = recognizer.velocity(in: view)
                 let slideMultiplier = abs(velocity.x) / 35000
-                let newPosition = boundContentNode(point: CGPoint(x: contentNode.position.x - (panGestureStartPoint.x - touchPoint!.x) + (velocity.x * slideMultiplier),
-                    y: contentNode!.position.y))
-                if abs(newPosition.x - panGestureStartContentPosition.x) < parentScene!.size.width * 1.4 {
-                    contentNode!.position = newPosition
+                let newPosition = boundContentNode(point: CGPoint(x: contentNode.position.x - (panGestureStartPoint.x - touchPoint.x) + (velocity.x * slideMultiplier),
+                    y: contentNode.position.y))
+                if abs(newPosition.x - panGestureStartContentPosition.x) < parentScene.size.width * 1.4 {
+                    contentNode.position = newPosition
                 }
-                panGestureStartPoint = touchPoint
+                self.panGestureStartPoint = touchPoint
             }
         }
         else if recognizer.state == UIGestureRecognizerState.ended {
             panGestureStartPoint = nil
             panGestureStartContentPosition = nil
             let page = getSelectedPage()
-            let point = CGPoint(x:-1.0 * CGFloat(page) * parentScene!.size.width, y:contentNode!.position.y)
+            let point = CGPoint(x:-1.0 * CGFloat(page) * parentScene.size.width, y:contentNode.position.y)
             let moveTo = SKAction.move(to: point, duration:0.2)
-            contentNode!.run(moveTo)
+            contentNode.run(moveTo)
             pageStateDidChange()
         }
     }
     
     private func pageStateDidChange() {
         let selectedPage = getSelectedPage()
-        for i in 0...pageIndicators!.count - 1 {
-            let circle = pageIndicators![i]
+        for i in 0..<pageIndicators.count {
+            let circle = pageIndicators[i]
             if i == selectedPage {
                 circle.fillColor = selectedColor
             }
@@ -145,7 +154,8 @@ public class PageControl: NSObject {
         if point.x > 0.0 {
             return CGPoint(x:0.0, y:point.y)
         }
-        let lowerBound = -1.0 * CGFloat(numberOfPages - 1) * parentScene!.size.width
+        guard let parentScene = parentScene else { return point }
+        let lowerBound = -1.0 * CGFloat(numberOfPages - 1) * parentScene.size.width
         if point.x < lowerBound {
             return CGPoint(x:lowerBound, y:point.y)
         }


### PR DESCRIPTION
🎯 **What:** 
Removed all implicitly unwrapped optionals (`!`) and force unwraps throughout `GBPageControl/PageControl.swift`.

⚠️ **Risk:** 
Unsafe force unwrapping of optionals exposes the library to crash vulnerabilities (Denial of Service). If arrays are empty, integer counts are 0, or nodes are unexpectedly nil during standard execution or via gesture tampering, a force unwrap causes an immediate, unrecoverable crash of the host application.

🛡️ **Solution:** 
- Converted implicitly unwrapped optional variables to standard optionals (`?`) or assigned safe default initial values (e.g., `SKNode()`, `[]`, `0`).
- Implemented `guard let` and `if let` statements across critical path methods like `handleTouch`, `getSelectedPage`, and `handlePanGesture` to safely bind and access optionals.
- Updated loops from `0...count - 1` to `0..<count` to resolve out-of-bounds array crashes.

*(Note: Unable to natively verify with a test suite as the current environment lacks `swift` and `xcodebuild` CLI tools, but visually verified syntactical safety.)*

---
*PR created automatically by Jules for task [5951392591658611571](https://jules.google.com/task/5951392591658611571) started by @jhurt*